### PR TITLE
Add `git graph` alias to the setup instructions.

### DIFF
--- a/_episodes/01-setup.md
+++ b/_episodes/01-setup.md
@@ -98,6 +98,13 @@ You can replace nano with vim, emacs or any other editor of your choice:
 $ git config --global core.editor nano
 ```
 
+We use a `git graph` alias very often (more info later).  Configure it
+like this:
+```shell
+$ git config --global alias.graph "log --all --graph --decorate --oneline"
+```
+
+
 To see where this information is stored, use:
 ```shell
 $ git config --list --show-origin


### PR DESCRIPTION
- It would be reasonable to not have it here and introduce it only
  when needed.  On the other hand, having a single place that gets
  everyone to the required configuration we need is good (a new
  student just needs to look at these instructions).  I don't know
  what the goal is, so this PR needs discussion...